### PR TITLE
Modifications to Medikit including private repos and uniform dependencies

### DIFF
--- a/medikit/feature/python.py
+++ b/medikit/feature/python.py
@@ -53,6 +53,7 @@ from medikit.globals import PIP_VERSION
 from medikit.resources.configparser import ConfigParserResource
 from medikit.utils import get_override_warning_banner
 
+from pprint import pprint
 
 def _normalize_requirement(req):
     """ Overrides the original method in Medikit, now it considers the special case of private repos """
@@ -92,7 +93,9 @@ class PythonConfig(Feature.Config):
         self._create_packages = True
         self.override_requirements = False
         self.use_wheelhouse = False
+        # Use the same requirement versions among all the extras, when requirements coincide.
         self.use_uniform_requirements = False
+        # Print the information of the "parent" requirement in the requirements*.txt files.
         self.show_comes_from_info = False
 
     @property
@@ -494,33 +497,6 @@ class PythonFeature(Feature):
         except IOError:
             version = "0.0.0"
         self.render_file_inline(python_config.version_file, "__version__ = '{}'".format(version))
-
-        # setup = python_config.get_setup()
-        #
-        # context = {
-        #     "url": setup.pop("url", "http://example.com/"),
-        #     "download_url": setup.pop("download_url", "http://example.com/"),
-        # }
-        #
-        # for k, v in context.items():
-        #     context[k] = context[k].format(name=setup["name"], user=getuser(), version="{version}")
-        #
-        # context.update(
-        #     {
-        #         "entry_points": setup.pop("entry_points", {}),
-        #         "extras_require": python_config.get("extras_require"),
-        #         "install_requires": python_config.get("install_requires"),
-        #         "python": python_config,
-        #         "setup": setup,
-        #         "banner": get_override_warning_banner(),
-        #     }
-        # )
-        #
-        # from pprint import pprint
-        # pprint(context)
-        #
-        # # Render (with overwriting) the allmighty setup.py
-        # self.render_file("setup.py", "python/setup.py.j2", context, override=True)
 
     @subscribe(medikit.on_end, priority=ABSOLUTE_PRIORITY)
     def on_end(self, event):

--- a/medikit/feature/python.py
+++ b/medikit/feature/python.py
@@ -33,14 +33,17 @@ import itertools
 import os
 import tempfile
 from getpass import getuser
+from types import SimpleNamespace
 
 from pip._vendor.distlib.util import parse_requirement
+from pip._internal.req.req_install import InstallRequirement
 from piptools._compat import parse_requirements
 from piptools.cache import DependencyCache
 from piptools.locations import CACHE_DIR
 from piptools.repositories import PyPIRepository
 from piptools.resolver import Resolver
 from piptools.utils import format_requirement
+from piptools.exceptions import IncompatibleRequirements
 
 import medikit
 from medikit.events import subscribe
@@ -52,10 +55,26 @@ from medikit.utils import get_override_warning_banner
 
 
 def _normalize_requirement(req):
-    bits = req.requirement.split()
+    """ Overrides the original method in Medikit, now it considers the special case of private repos """
+
+    if req.constraints and not req.url:
+        bits = req.requirement.split()
+    else:
+        bits = [req.requirement, '@', req.url]
+
     if req.extras:
         bits = [bits[0] + "[{}]".format(",".join(req.extras))] + bits[1:]
+
     return " ".join(bits)
+
+def _get_valid_link_req(req):
+    """ Formats the repo based dependencies, which can be dirty in case of collision between repo based and package
+     based declarations (for similar packages) """
+
+    tokens = str(req).split("@")
+    req_name = parse_requirement(tokens[0])
+
+    return req_name.name + "@ " + "@".join(tokens[1:])
 
 
 class PythonConfig(Feature.Config):
@@ -73,6 +92,8 @@ class PythonConfig(Feature.Config):
         self._create_packages = True
         self.override_requirements = False
         self.use_wheelhouse = False
+        self.use_uniform_requirements = False
+        self.show_comes_from_info = False
 
     @property
     def package_dir(self):
@@ -216,6 +237,66 @@ class PythonConfig(Feature.Config):
                 self._vendors[extra] = []
         for req in reqs:
             self._vendors[extra].append(req)
+
+    def get_requirement_info_by_name(self, req, requirements_by_name=dict()):
+        """ Given a requirement, it provides its valid information to be included in the final file """
+
+        if self.use_uniform_requirements:
+            # If it is a repo and not a package, this will be True
+            if req.link:
+                requirement_name = parse_requirement(_get_valid_link_req(req.req)).name
+            else:
+                requirement_name = parse_requirement(str(req.req)).name
+
+            # If the requirement is not in the dict, it is because it was not needed as a dependency in the original
+            # set containing all requirements
+            if requirement_name in requirements_by_name.keys():
+                # In case we want to show the source for inherited dependencies
+                if self.show_comes_from_info and type(req.comes_from) == InstallRequirement:
+                    return "{}\t\t\t# From: {}".format(requirements_by_name[requirement_name].requirement,
+                                                       str(req.comes_from.req))
+                else:
+                    return requirements_by_name[requirement_name].requirement
+
+            else:
+                return None
+        else:
+            # If not using uniform versions, we just need to provide the information based on wether it is
+            # a repository or a package
+            if self.show_comes_from_info and type(req.comes_from) == InstallRequirement:
+                return "{}\t\t\t# From: {}".format(format_requirement(req) if not req.link else str(req.req),
+                                                   str(req.comes_from.req))
+            else:
+                return format_requirement(req) if not req.link else str(req.req)
+
+    def _check_duplicate_dependencies_by_extra(self, extra, requirements_by_name):
+        """ Checks there are not duplicate dependencies, in the case of private repositories"""
+
+        for name, req in sorted(self._requirements[extra].items()):
+            requirement_str = req.requirement if not req.url else req.url.strip().replace(" ", "")
+
+            if name not in requirements_by_name.keys():
+                # This can happen if additional requirements are included from the outside, for instance with pytest
+                continue
+
+            if (req.url or requirements_by_name[name].url) and requirements_by_name[name].requirement != requirement_str:
+                raise IncompatibleRequirements(req, requirements_by_name[name].url)
+
+    def check_duplicate_dependencies_uniform(self, requirements_by_name):
+        """ Checks there are not duplicate dependencies, when use_uniform_requirements==True """
+        for extra in itertools.chain((None,), self.get_extras()):
+            self._check_duplicate_dependencies_by_extra(extra, requirements_by_name)
+
+    def check_duplicate_dependencies_nonuniform(self, extra, resolver):
+        """ Checks there are not duplicate dependencies, when use_uniform_requirements==False """
+        requirements_by_name = {}
+        for req in resolver.resolve(max_rounds=10):
+            requirements_by_name[parse_requirement(str(req.req)).name] = SimpleNamespace(
+                requirement=format_requirement(req).strip().replace(" ", ""),
+                url=req.link
+            )
+
+        self._check_duplicate_dependencies_by_extra(extra, requirements_by_name)
 
 
 class PythonFeature(Feature):
@@ -414,11 +495,130 @@ class PythonFeature(Feature):
             version = "0.0.0"
         self.render_file_inline(python_config.version_file, "__version__ = '{}'".format(version))
 
+        # setup = python_config.get_setup()
+        #
+        # context = {
+        #     "url": setup.pop("url", "http://example.com/"),
+        #     "download_url": setup.pop("download_url", "http://example.com/"),
+        # }
+        #
+        # for k, v in context.items():
+        #     context[k] = context[k].format(name=setup["name"], user=getuser(), version="{version}")
+        #
+        # context.update(
+        #     {
+        #         "entry_points": setup.pop("entry_points", {}),
+        #         "extras_require": python_config.get("extras_require"),
+        #         "install_requires": python_config.get("install_requires"),
+        #         "python": python_config,
+        #         "setup": setup,
+        #         "banner": get_override_warning_banner(),
+        #     }
+        # )
+        #
+        # from pprint import pprint
+        # pprint(context)
+        #
+        # # Render (with overwriting) the allmighty setup.py
+        # self.render_file("setup.py", "python/setup.py.j2", context, override=True)
+
+    @subscribe(medikit.on_end, priority=ABSOLUTE_PRIORITY)
+    def on_end(self, event):
+
+        # Our config object
+        python_config = event.config["python"]
+
+        # Pip / PyPI
+        repository = PyPIRepository([], cache_dir=CACHE_DIR)
+        # repository = PyPIRepository([], cache_dir=tempfile.mkdtemp())
+
+        # We just need to construct this structure if use_uniform_requirements == True
+        requirements_by_name = {}
+
+        if python_config.use_uniform_requirements:
+            tmpfile = tempfile.NamedTemporaryFile(mode="wt", delete=False)
+            for extra in itertools.chain((None,), python_config.get_extras()):
+                tmpfile.write("\n".join(python_config.get_requirements(extra=extra)) + "\n")
+                tmpfile.flush()
+
+            constraints = list(
+                parse_requirements(
+                    tmpfile.name, finder=repository.finder, session=repository.session, options=repository.options
+                )
+            )
+
+            # This resolver is able to evaluate ALL the dependencies along the extras
+            resolver = Resolver(
+                constraints,
+                repository,
+                cache=DependencyCache(CACHE_DIR),
+                # cache=DependencyCache(tempfile.tempdir),
+                prereleases=False,
+                clear_caches=False,
+                allow_unsafe=False,
+            )
+
+            for req in resolver.resolve(max_rounds=10):
+                requirements_by_name[parse_requirement(str(req.req)).name] = SimpleNamespace(
+                    requirement=format_requirement(req).strip().replace(" ", ""),
+                    url=req.link
+                )
+
+            python_config.check_duplicate_dependencies_uniform(requirements_by_name)
+
+        # Now it iterates along the versions in extras and looks for the requirements and its dependencies, using the
+        # structure created above to select the unified versions (unless the flag indicates otherwise).
+        for extra in itertools.chain((None,), python_config.get_extras()):
+            requirements_file = "requirements{}.txt".format("-" + extra if extra else "")
+
+            if python_config.override_requirements or not os.path.exists(requirements_file):
+                tmpfile = tempfile.NamedTemporaryFile(mode="wt", delete=False)
+                tmpfile.write("\n".join(python_config.get_requirements(extra=extra)) + "\n")
+                tmpfile.flush()
+
+                constraints = list(
+                    parse_requirements(
+                        tmpfile.name, finder=repository.finder, session=repository.session, options=repository.options
+                    )
+                )
+                resolver = Resolver(
+                    constraints,
+                    repository,
+                    cache=DependencyCache(CACHE_DIR),
+                    prereleases=False,
+                    clear_caches=False,
+                    allow_unsafe=False,
+                )
+
+                if not python_config.use_uniform_requirements:
+                    python_config.check_duplicate_dependencies_nonuniform(extra, resolver)
+
+                requirements_list = []
+                for req in resolver.resolve(max_rounds=10):
+                    if req.name != python_config.get("name"):
+                        requirement = python_config.get_requirement_info_by_name(req, requirements_by_name)
+                        if requirement:
+                            requirements_list.append(requirement)
+
+                self.render_file_inline(
+                    requirements_file,
+                    "\n".join(
+                        (
+                            "-e .{}".format("[" + extra + "]" if extra else ""),
+                            *(("-r requirements.txt",) if extra else ()),
+                            *python_config.get_vendors(extra=extra),
+                            *sorted(requirements_list),
+                        )
+                    ),
+                    override=python_config.override_requirements,
+                )
+
+        # Updates setup file
         setup = python_config.get_setup()
 
         context = {
-            "url": setup.pop("url", "http://example.com/"),
-            "download_url": setup.pop("download_url", "http://example.com/"),
+            "url": setup.pop("url", ""),
+            "download_url": setup.pop("download_url", ""),
         }
 
         for k, v in context.items():
@@ -435,54 +635,8 @@ class PythonFeature(Feature):
             }
         )
 
+        from pprint import pprint
+        pprint(context)
+
         # Render (with overwriting) the allmighty setup.py
         self.render_file("setup.py", "python/setup.py.j2", context, override=True)
-
-    @subscribe(medikit.on_end, priority=ABSOLUTE_PRIORITY)
-    def on_end(self, event):
-        # Our config object
-        python_config = event.config["python"]
-
-        # Pip / PyPI
-        repository = PyPIRepository([], cache_dir=CACHE_DIR)
-
-        for extra in itertools.chain((None,), python_config.get_extras()):
-            requirements_file = "requirements{}.txt".format("-" + extra if extra else "")
-
-            if python_config.override_requirements or not os.path.exists(requirements_file):
-                tmpfile = tempfile.NamedTemporaryFile(mode="wt", delete=False)
-                if extra:
-                    tmpfile.write("\n".join(python_config.get_requirements(extra=extra)))
-                else:
-                    tmpfile.write("\n".join(python_config.get_requirements()))
-                tmpfile.flush()
-                constraints = list(
-                    parse_requirements(
-                        tmpfile.name, finder=repository.finder, session=repository.session, options=repository.options
-                    )
-                )
-                resolver = Resolver(
-                    constraints,
-                    repository,
-                    cache=DependencyCache(CACHE_DIR),
-                    prereleases=False,
-                    clear_caches=False,
-                    allow_unsafe=False,
-                )
-
-                self.render_file_inline(
-                    requirements_file,
-                    "\n".join(
-                        (
-                            "-e .{}".format("[" + extra + "]" if extra else ""),
-                            *(("-r requirements.txt",) if extra else ()),
-                            *python_config.get_vendors(extra=extra),
-                            *sorted(
-                                format_requirement(req)
-                                for req in resolver.resolve(max_rounds=10)
-                                if req.name != python_config.get("name")
-                            ),
-                        )
-                    ),
-                    override=python_config.override_requirements,
-                )

--- a/medikit/feature/python.py
+++ b/medikit/feature/python.py
@@ -55,7 +55,7 @@ from medikit.utils import get_override_warning_banner
 
 
 def _normalize_requirement(req):
-    """ Overrides the original method in Medikit, now it considers the special case of private repos """
+    """ Normalizes the requirement string. It considers the case of having or not an URL """
 
     if req.constraints and not req.url:
         bits = req.requirement.split()
@@ -505,7 +505,6 @@ class PythonFeature(Feature):
 
         # Pip / PyPI
         repository = PyPIRepository([], cache_dir=CACHE_DIR)
-        # repository = PyPIRepository([], cache_dir=tempfile.mkdtemp())
 
         # We just need to construct this structure if use_uniform_requirements == True
         requirements_by_name = {}

--- a/medikit/feature/python.py
+++ b/medikit/feature/python.py
@@ -53,7 +53,6 @@ from medikit.globals import PIP_VERSION
 from medikit.resources.configparser import ConfigParserResource
 from medikit.utils import get_override_warning_banner
 
-from pprint import pprint
 
 def _normalize_requirement(req):
     """ Overrides the original method in Medikit, now it considers the special case of private repos """


### PR DESCRIPTION
This is just to check we are on the same page before sending a PR to Medikit. As happened with our locally modified version:

New parameters provided:

- `python.use_uniform_requirements`: If True, requirements are set to be the same for all the extras when there are coincidences, directly or on the inherited dependencies.
- `python.show_comes_from_info`: If True, information about the origin of a dependency is shown.

Valid requirement examples:
```
boto3 ~=1.10,
requirement_1 @ git+https://{token}@github.com/user_name/requirement_1.git@{checkpoint_or_tag},
requirement_2 @ git+ssh://git@github.com/user_name/requirement_2.git,
```
Projectfile usage example:
```
# Test (see github.com/python-medikit)

from medikit import require

NAME = 'Test'

with require('python') as python:
    python.setup(
        name=NAME,
        description='This is just a test',
        license='Apache License, Version 2.0',
        url='http://www.an-example.com/',
        download_url='http://www.an-example.com/',
        author='An author',
        author_email='author@email.com',
    )

    # New parameters are configured as follows
    python.use_uniform_requirements = True
    python.show_comes_from_info = True

   # You can try commenting/uncommenting the following to see the behavior
    python.add_requirements(
        'boto3 ~=1.10',
        # f'httpie @ git+https://github.com/httpie/httpie.git@2.3.0',
        dev=[
            'boto3 ~= 1.11',
            # 'httpie >= 2.2.0',
            # f'httpie @ git+https://github.com/httpie/httpie.git@2.4.0',
        ],
        extra1=[
            'boto3 == 1.12',
            # f'httpie @ git+https://{token}@github.com/httpie/httpie.git@5945845420c019db81e8c09f0ce174a7eeebcdd8',
            f'httpie @ git+https://github.com/httpie/httpie.git@1.0.2',
            # 'httpie < 2.4.0'
        ],
        extra2=[
            'boto3 ~=1.11',
            # f'httpie @ git+https://github.com/httpie/httpie.git@1.0.1',
        ],
        extra3=[
            # 'boto3 == 1.12',
            # 'httpie == 2.2.0',
        ]
    )

with require('git') as git:
    pass

with require('make') as make:
    pass

# vim: ft=python:
```
- In a git repository, if there are submodules, it will explore them along all of them
- If `use_uniform_requirements== True`, requirement versions will be unified among all the extras.
NOTE: In case a private repository version is mixed with a different version from another repository, or even with
a packaged version (included inherited versions), an IncompatibleRequirements exception will be triggered.

For instance, the example above will become:
```
cat requirements.txt 

-e .
boto3==1.12.0
botocore==1.15.49                       # From: boto3==1.17.45
jmespath==0.10.0                        # From: boto3==1.17.45
python-dateutil==2.8.1                  # From: botocore==1.20.45
s3transfer==0.3.6                       # From: boto3==1.17.45
six==1.15.0                     # From: python-dateutil==2.8.1
urllib3==1.25.11                        # From: botocore==1.20.45
```

```
cat requirements-dev.txt

-e .[dev]
-r requirements.txt
boto3==1.12.0
botocore==1.15.49                       # From: boto3==1.17.45
jmespath==0.10.0                        # From: boto3==1.17.45
python-dateutil==2.8.1                  # From: botocore==1.20.45
s3transfer==0.3.6                       # From: boto3==1.17.45
six==1.15.0                     # From: python-dateutil==2.8.1
urllib3==1.25.11                        # From: botocore==1.20.45
```

```
cat requirements-extra1.txt

-e .[extra1]
-r requirements.txt
boto3==1.12.0
botocore==1.15.49                       # From: boto3==1.12
certifi==2020.12.5                      # From: requests==2.25.1
chardet==4.0.0                  # From: requests==2.25.1
docutils==0.15.2                        # From: botocore==1.15.49
git+https://github.com/httpie/httpie.git@1.0.2
idna==2.10                      # From: requests==2.25.1
jmespath==0.10.0                        # From: boto3==1.12
pygments==2.8.1                 # From: httpie@ git+https://github.com/httpie/httpie.git@1.0.2
python-dateutil==2.8.1                  # From: botocore==1.15.49
requests==2.25.1                        # From: httpie@ git+https://github.com/httpie/httpie.git@1.0.2
s3transfer==0.3.6                       # From: boto3==1.12
six==1.15.0                     # From: python-dateutil==2.8.1
urllib3==1.25.11                        # From: botocore==1.15.49
```

```
cat requirements-extra2.txt
-e .[extra2]
-r requirements.txt
boto3==1.12.0
botocore==1.15.49                       # From: boto3==1.17.45
jmespath==0.10.0                        # From: boto3==1.17.45
python-dateutil==2.8.1                  # From: botocore==1.20.45
s3transfer==0.3.6                       # From: boto3==1.17.45
six==1.15.0                     # From: python-dateutil==2.8.1
urllib3==1.25.11                        # From: botocore==1.20.45
```

```
cat setup.py 
# Generated by Medikit 0.8.0 on 2021-04-06.
# All changes will be overriden.
# Edit Projectfile and run “make update” (or “medikit update”) to regenerate.

from setuptools import setup, find_packages
from codecs import open
from os import path

here = path.abspath(path.dirname(__file__))

# Py3 compatibility hacks, borrowed from IPython.
try:
    execfile
except NameError:

    def execfile(fname, globs, locs=None):
        locs = locs or globs
        exec(compile(open(fname).read(), fname, "exec"), globs, locs)


# Get the long description from the README file
try:
    with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
        long_description = f.read()
except:
    long_description = ''

# Get the classifiers from the classifiers file
tolines = lambda c: list(filter(None, map(lambda s: s.strip(), c.split('\n'))))
try:
    with open(path.join(here, 'classifiers.txt'), encoding='utf-8') as f:
        classifiers = tolines(f.read())
except:
    classifiers = []

version_ns = {}
try:
    execfile(path.join(here, 'Test/_version.py'), version_ns)
except EnvironmentError:
    version = 'dev'
else:
    version = version_ns.get('__version__', 'dev')

setup(
    author='An author',
    author_email='author@email.com',
    description='This is just a test',
    license='Apache License, Version 2.0',
    name='Test',
    version=version,
    long_description=long_description,
    classifiers=classifiers,
    packages=find_packages(exclude=['ez_setup', 'example', 'test']),
    include_package_data=True,
    install_requires=['boto3 ~= 1.10'],
    extras_require={
        'dev': ['boto3 ~= 1.11'],
        'extra1': [
            'boto3 == 1.12',
            'httpie @ git+https://github.com/httpie/httpie.git@1.0.2'
        ],
        'extra2': ['boto3 ~= 1.11']
    },
    url='http://www.an-example.com/',
    download_url='http://www.an-example.com/'.format(version=version),
)
```


